### PR TITLE
Add Plugin: UID Generator & Callout Autocomplete

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16511,6 +16511,20 @@
     "author": "qf3l3k",
     "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
     "repo": "qf3l3k/obsidian-api-fetcher"
+  },
+  {
+    "id": "unique-id-generator",
+    "name": "UID Generator",
+    "author": "Albert Bekaev",
+    "description": "Adds unique IDs to Obsidian notes frontmatter",
+    "repo": "albertuss/obsidian-uid-generator"
+  },
+  {
+    "id": "callout-autocomplete",
+    "name": "Callout Autocomplete",
+    "author": "Albert Beakev",
+    "description": "Autocomplete dropdown for callout types with icons and colors",
+    "repo": "albertuss/obsidian-callout-autocomplete"
   }
 ]
 


### PR DESCRIPTION
This PR adds two new plugins to the Obsidian community plugins list:
- UID Generator: Adds unique IDs to Obsidian notes frontmatter (https://github.com/albertuss/obsidian-uid-generator)
- Callout Autocomplete: Autocomplete dropdown for callout types (https://github.com/albertuss/obsidian-callout-autocomplete)